### PR TITLE
defaults to jewlr region when the region doesn't exist

### DIFF
--- a/lib/factory_days.rb
+++ b/lib/factory_days.rb
@@ -19,7 +19,11 @@ module ActiveSupport
                            end
 
           is_holiday = if holiday_region
-                         Holidays.on(self, *holiday_region, :observed).any?
+                         begin
+                           Holidays.on(self, *holiday_region, :observed).any?
+                         rescue Holidays::UnknownRegionError
+                           Holidays.on(self, 'jewlr', :observed).any?
+                         end
                        else
                          Holidays.on(self, :observed).any?
                        end
@@ -176,7 +180,11 @@ module ActiveSupport
                            end
 
           is_holiday = if holiday_region
-                         Holidays.on(self, *holiday_region, :observed).any?
+                         begin
+                           Holidays.on(self, *holiday_region, :observed).any?
+                         rescue Holidays::UnknownRegionError
+                           Holidays.on(self, 'jewlr', :observed).any?
+                         end
                        else
                          Holidays.on(self, :observed).any?
                        end

--- a/lib/factory_days/version.rb
+++ b/lib/factory_days/version.rb
@@ -1,3 +1,3 @@
 module FactoryDays
-  VERSION = '0.2.18'
+  VERSION = '0.2.19'
 end


### PR DESCRIPTION
When the region doesn't exist due to a manufacturer (ie. Suashish), the gem was throwing an exception. Now it will use Jewlr instead.