### PR TITLE
defaults to jewlr region when the region doesn't exist

### DIFF
--- a/lib/factory_days.rb
+++ b/lib/factory_days.rb
@@ -18,7 +18,11 @@ module ActiveSupport
 
           raise 'Missing required :holiday_region option' unless holiday_region
 
-          is_holiday = Holidays.on(self, *holiday_region, :observed).any?
+          begin
+            is_holiday = Holidays.on(self, *holiday_region, :observed).any?
+          rescue Holidays::UnknownRegionError
+            is_holiday = Holidays.on(self, 'jewlr', :observed).any?
+          end
 
           if !is_holiday && (
                (1..5).cover?(wday) ||
@@ -166,7 +170,12 @@ module ActiveSupport
 
           raise 'Missing required :holiday_region option' unless holiday_region
 
-          is_holiday = Holidays.on(self, *holiday_region, :observed).any?
+          begin
+            is_holiday = Holidays.on(self, *holiday_region, :observed).any?
+          rescue Holidays::UnknownRegionError
+            is_holiday = Holidays.on(self, 'jewlr', :observed).any?
+          end
+
           if !is_holiday && (
                (1..5).cover?(wday) ||
                options[:include_saturday] && wday == 6 ||

--- a/lib/factory_days/version.rb
+++ b/lib/factory_days/version.rb
@@ -1,3 +1,3 @@
 module FactoryDays
-  VERSION = '0.2.22'
+  VERSION = '0.2.23'
 end


### PR DESCRIPTION
Default to Jewlr if a region doesn't exist. That could happen on special manufacturers like Suashish